### PR TITLE
Fixed regular expression for data URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var childProcess = require('child_process');
 
 var phantomjsScript = path.resolve(__dirname, './phantomjs-script.js');
 
-var backgroundImageRegex = /url\(('|")?(([^\1]+\.svg)|(data:image\/svg\+xml;[^\1]+))\1\)/;
+var backgroundImageRegex = /url\(('|")?(([^\1]+\.svg)|(data:image\/svg\+xml[;,][^\1]+))\1\)/;
 var backgroundSizeRegex = /^(\d+)px( (\d+)px)?$/;
 
 function hash(input) {


### PR DESCRIPTION
Comma can be a delimiter as well as semicolon.

I found this when using the plugin with [postcss-svg](https://github.com/Pavliko/postcss-svg) which using comma as delimiter after `data:image/svg+xml`
