### PR TITLE
Fix for correct resolving dest path

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ module.exports = postcss.plugin('postcss-svg-fallback', function(options) {
 
 function processImage(options, image, cb) {
 	var source = path.resolve(options.basePath || '', image.image);
-	var dest = path.resolve(options.dest || '', image.newImage);
+	var dest = path.resolve(path.join(process.cwd(), options.dest || '') || '', image.newImage);
 
 	var args = [
 		phantomjsScript,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"type": "git",
 		"url": "git://github.com/justim/postcss-svg-fallback"
 	},
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"main": "index.js",
 	"dependencies": {
 		"postcss": "~4.1.9",


### PR DESCRIPTION
`path.resolve` resolves path from root of current disk if `options.dest` is defined and starts with `/`.
It is a bit confusing.
