### PR TITLE
Inline mode not rewrites file if it is exists.

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ function processImage(options, image, cb) {
 	];
 
 	if (image.inline) {
-		statDest(null, dest, args, cb);
+		statDest('inline', dest, args, cb);
 	} else {
 		fs.stat(source, function(sourceErr, sourceStat) {
 			if (sourceStat) {
@@ -162,7 +162,7 @@ function processImage(options, image, cb) {
 
 function statDest(sourceStat, dest, args, cb) {
 	fs.stat(dest, function(destErr, destStat) {
-		if (!destStat || !sourceStat || sourceStat.mtime > destStat.mtime) {
+		if (!destStat || !sourceStat || sourceStat !== 'inline' || sourceStat.mtime > destStat.mtime) {
 			runPhantomJs(args, cb);
 		} else {
 			cb();

--- a/test/test.js
+++ b/test/test.js
@@ -148,6 +148,27 @@ describe('svg-fallback', function() {
 			});
 		});
 
+		it('should not rewrite a file if hashes are equals', function(done) {
+			return transform(inputCss).then(function() {
+				fs.stat(generatedImagePath, function(generatedImageError, generatedStatsFirst) {
+					if (!generatedImageError) {
+						transform(inputCss).then(function() {
+							fs.stat(generatedImagePath, function(generatedImageError, generatedStatsSecond) {
+								if (!generatedImageError) {
+									expect(generatedStatsSecond.mtime.getTime()).to.eql(generatedStatsFirst.mtime.getTime());
+									done();
+								} else {
+									done(generatedImageError);
+								}
+							});
+						});
+					} else {
+						done(generatedImageError);
+					}
+				});
+			});
+		});
+
 	});
 
 	describe('multiple-selector', function() {


### PR DESCRIPTION
Now the plugin checks the output file not only in file-mode (by timestamps) but also in inline-mode by hash, which is used in file name. So if expected file is exists it means that hash wasn't changed.
