### PR TITLE
Extend options in tests with given extraOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 	},
 	"devDependencies": {
 		"mocha": "",
-		"chai": ""
+		"chai": "",
+		"extend": ""
 	},
 	"keywords": [
 		"postcss",

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@
 var fs = require('fs');
 
 var expect = require('chai').expect;
+var extend = require('extend');
 
 var postcss = require('postcss');
 var svgFallback = require('../index.js');
@@ -16,8 +17,8 @@ function transform(input, extraOptions) {
 		dest: 'test',
 	};
 
-	if (extraOptions && extraOptions.disableConvert) {
-		options = extraOptions.disableConvert;
+	if (extraOptions) {
+		extend(true, options, extraOptions);
 	}
 
 	return postcss()


### PR DESCRIPTION
When extra options is presented, it will overwrite all options with single value. I think that extending the base options is more accurate.
